### PR TITLE
Fixed methods lacking parentheses

### DIFF
--- a/ontouml/src/main/groovy/net/menthor/ontouml/rule/GenericCondition.groovy
+++ b/ontouml/src/main/groovy/net/menthor/ontouml/rule/GenericCondition.groovy
@@ -235,7 +235,7 @@ abstract class GenericCondition {
     }
 
     static boolean isMetaAttributeIfWholeIs(OntoUMLRelationship self, String relStereotypeMethod, String metaAttrMethod, boolean value, String wholeStereotypeMethod){
-        if(self."${relStereotypeMethod}"() && self.wholeClass()!=null && self.wholeClass()."${wholeStereotypeMethod}"){
+        if(self."${relStereotypeMethod}"() && self.wholeClass()!=null && self.wholeClass()."${wholeStereotypeMethod}"()){
             def result = self."${metaAttrMethod}"()==value
             return result
         }
@@ -243,7 +243,7 @@ abstract class GenericCondition {
     }
 
     static boolean isMetaAttributeIfPartIs(OntoUMLRelationship self, String relStereotypeMethod, String metaAttrMethod, boolean value, String partStereotypeMethod){
-        if(self."${relStereotypeMethod}"() && self.partClass()!=null && self.partClass()."${partStereotypeMethod}"){
+        if(self."${relStereotypeMethod}"() && self.partClass()!=null && self.partClass()."${partStereotypeMethod}"()){
             def result = self."${metaAttrMethod}"()==value
             return result
         }


### PR DESCRIPTION
Inside methods isMetaAttributeIfWholeIs and isMetaAttributeIfPartIs (GenericCondition class), the methods in the end of the if clauses lacked parentheses.